### PR TITLE
run test to tmp dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install:
   - pip install .
 # command to run tests
-script: pytest
+script: pytest --basetemp=temp_dir

--- a/test/test_examples/conftest.py
+++ b/test/test_examples/conftest.py
@@ -12,10 +12,10 @@ def basepath() -> str:
     return os.path.dirname(os.path.abspath(__file__))
 
 @pytest.fixture
-def run_task(basepath) -> Callable:
+def run_task(tmpdir) -> Callable:
     def _run_task(scenario, task_name, expected_location):
-        conf = os.path.join(basepath, '../../examples', scenario, 'conf')
-        data = os.path.join(basepath, '../../examples', scenario, 'data')
+        conf = os.path.join(tmpdir, '../../examples', scenario, 'conf')
+        data = os.path.join(tmpdir, '../../examples', scenario, 'data')
         task = Task.build(conf, data, task_name)
         task.run()
         actual_path = os.path.join(


### PR DESCRIPTION
i was searching all day but its quite not possible what you are asking for, as pytest running tests in temp folder is generating new directories on every run, so this is quite a workaround, when running pytest you are setting temp directory and all tests are run in this directory, if that's not what you need, i have no problem on canceling contract, since i cant find any good solution for your problem.