### PR TITLE
Removed PathLocator from Step.build, moved test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,11 +105,12 @@ venv.bak/
 *.DS_Store
 
 # test results
-examples/s_1_mm_only/data/entities/person/actual
-examples/s_2_mm_scan/data/entities/person/actual
+test_output
+#examples/s_1_mm_only/data/entities/person/actual
+#examples/s_2_mm_scan/data/entities/person/actual
 examples/s_3_mm_aggregate_mm_scan/data/entities/city/origin
-examples/s_4_filter_mm_scan/data/entities/person/actual
-examples/s_5_tr_export/count_output.txt
-examples/s_5_tr_export/immutable.csv
-examples/s_5_tr_export/records.json
-examples/s_5_tr_export/temporal.csv
+#examples/s_4_filter_mm_scan/data/entities/person/actual
+#examples/s_5_tr_export/count_output.txt
+#examples/s_5_tr_export/immutable.csv
+#examples/s_5_tr_export/records.json
+#examples/s_5_tr_export/temporal.csv

--- a/examples/s_5_tr_export/conf/consumers/count.py
+++ b/examples/s_5_tr_export/conf/consumers/count.py
@@ -15,7 +15,7 @@ class Count(Consume):
         self.n += 1
 
     def after(self):
-        filename = os.path.join(self.path_locator.conf_dir, '../', self.filename)
+        filename = os.path.join(self.output_dir, self.filename)
         filepath = os.path.dirname(filename)
         if not os.path.exists(filepath):
             os.makedirs(filepath)

--- a/polytropos/actions/aggregate.py
+++ b/polytropos/actions/aggregate.py
@@ -9,7 +9,6 @@ from functools import partial
 from polytropos.ontology.composite import Composite
 
 from polytropos.actions.step import Step
-from polytropos.ontology.paths import PathLocator
 from polytropos.ontology.variable import Variable
 from polytropos.util.loader import load
 from polytropos.ontology.schema import Schema
@@ -27,10 +26,10 @@ class Aggregate(Step):
     # noinspection PyMethodOverriding
     @classmethod
     def build(
-            cls, path_locator: PathLocator, schema: Schema, name: str, target_schema: str, id_var: str,
-            input_mappings: Dict, output_mappings: Dict
-    ): 
-        target_schema_instance: Schema = Schema.load(target_schema, path_locator=path_locator)
+            cls, *, schema: Schema, schemas_dir: str, name: str, target_schema: str, id_var: str,
+            input_mappings: Dict, output_mappings: Dict, **kwargs_ignore
+    ) -> "Aggregate": 
+        target_schema_instance: Schema = Schema.load(target_schema, base_path=schemas_dir)
         aggregations: Dict[str, Type] = load(cls)
         return aggregations[name](origin_schema=schema, target_schema=target_schema_instance, id_var=id_var,
                                   **input_mappings, **output_mappings)

--- a/polytropos/actions/consume.py
+++ b/polytropos/actions/consume.py
@@ -8,19 +8,20 @@ from polytropos.ontology.composite import Composite
 from polytropos.actions.step import Step
 from polytropos.ontology.schema import Schema
 from polytropos.util.loader import load
-from polytropos.ontology.paths import PathLocator
 
 
 @dataclass
 class Consume(Step):
-    path_locator: PathLocator
     schema: Schema
+    output_dir: str
+    lookups_dir: str
+    schemas_dir: str
 
     """Export data from a set of composites to a single file."""
     @classmethod
-    def build(cls, path_locator: PathLocator, schema: Schema, name: str, **kwargs):
+    def build(cls, *, schema: Schema, output_dir: str, name: str, **kwargs):
         consumes = load(cls)
-        return consumes[name](path_locator, schema, **kwargs)
+        return consumes[name](schema=schema, output_dir=output_dir, **kwargs)
 
     def before(self):
         """Optional actions to be performed after the constructor runs but before starting to consume composites."""
@@ -56,7 +57,7 @@ class ExportToJSON(Consume):
     def before(self):
         # noinspection PyAttributeOutsideInit
         self.fobj = open(
-            os.path.join(self.path_locator.conf, '../', self.filename), 'w'
+            os.path.join(self.output_dir, self.filename), 'w'
         )
         self.fobj.write('{\n')
 

--- a/polytropos/actions/evolve/__evolve.py
+++ b/polytropos/actions/evolve/__evolve.py
@@ -16,11 +16,10 @@ from polytropos.actions.step import Step
 from polytropos.util.config import MAX_WORKERS
 
 if TYPE_CHECKING:
-    from polytropos.ontology.paths import PathLocator
     from polytropos.ontology.schema import Schema
 
 class _EvolveFactory(Callable):
-    def __init__(self, path_locator: "PathLocator",
+    def __init__(self, lookups_dir: str,
                  change_specs: List[Dict],
                  schema: "Schema",
                  requested_lookups: Optional[List[str]]):
@@ -29,13 +28,13 @@ class _EvolveFactory(Callable):
         self.requested_lookups: List[str] = requested_lookups or []
         self.change_specs: List[Dict] = change_specs
         self.schema: "Schema" = schema
-        self.path_locator: "PathLocator" = path_locator
+        self.lookups_dir: str = lookups_dir
 
     def _load_lookups(self) -> Dict[str, Dict]:
         loaded_lookups: Dict = {}
         lookups = self.requested_lookups
         for lookup in lookups:
-            with open(os.path.join(self.path_locator.lookups_dir, lookup + '.json'), 'r') as l:
+            with open(os.path.join(self.lookups_dir, lookup + '.json'), 'r') as l:
                 loaded_lookups[lookup] = json.load(l)
         return loaded_lookups
 
@@ -56,29 +55,30 @@ class _EvolveFactory(Callable):
     def __call__(self, cls: Type) -> "Evolve":
         loaded_lookups: Dict[str, Dict] = self._load_lookups()
         change_instances: List[Change] = list(self._construct_changes(loaded_lookups))
-        return cls(self.path_locator, change_instances, self.schema)
+        return cls(self.lookups_dir, change_instances, self.schema)
 
 class Evolve(Step):
     """A metamorphosis represents a series of changes that are made to a single composite, in order, and without
     reference to any other composite. Each change is defined in terms of one or more subject variables, which may be
     inputs, outputs, or both (in a case where a change alters a value in place)."""
 
-    def __init__(self, path_locator: "PathLocator", changes: List[Change], schema: "Schema"):
-        self.path_locator = path_locator
+    def __init__(self, lookups_dir: str, changes: List[Change], schema: "Schema"):
+        self.lookups_dir = lookups_dir
         self.changes = changes
         self.schema = schema
 
     # noinspection PyMethodOverriding
     @classmethod
-    def build(cls, *, path_locator: "PathLocator", schema: "Schema", changes: List[Dict], lookups: List[str]=None) -> "Evolve":
+    def build(cls, *, schema: "Schema", lookups_dir: str, changes: List[Dict], lookups: List[str]=None, **kwargs_ignore
+                    ) -> "Evolve":
         """Loads in the specified lookup tables, constructs the specified Changes, and passes these Changes to the
         constructor.
-        :param path_locator: Helper class that finds requested files in a configuration path.
         :param changes: List of change definitions (from the task YAML file)
+        :param lookups_dir: Directory containing the json lookup tables.
         :param schema: The schema on which the composites are expected to be based.
         :param lookups: A list of key-value lookups expected to be available during each Change.
         """
-        do_build: Callable = _EvolveFactory(path_locator, changes, schema, lookups)
+        do_build: Callable = _EvolveFactory(lookups_dir, changes, schema, lookups)
         return do_build(cls)
 
     def process_composite(self, origin, target, filename) -> Optional[ExceptionWrapper]:

--- a/polytropos/actions/filter.py
+++ b/polytropos/actions/filter.py
@@ -23,7 +23,7 @@ class Filter(Step):
     schema: Schema
 
     @classmethod
-    def build(cls, path_locator, schema: Schema, name: str, mappings: Dict):
+    def build(cls, *, schema: Schema, name: str, mappings: Dict, **kwargs_ignore) -> "Filter":
         logging.info('Building instance of filter class "%s"' % name)
         filters = load(cls)
         return filters[name](schema=schema, **mappings)

--- a/polytropos/actions/scan.py
+++ b/polytropos/actions/scan.py
@@ -14,7 +14,6 @@ from polytropos.util.loader import load
 from polytropos.util.config import MAX_WORKERS
 
 if TYPE_CHECKING:
-    from polytropos.ontology.paths import PathLocator
     from polytropos.ontology.schema import Schema
 
 @dataclass
@@ -28,7 +27,7 @@ class Scan(Step):
 
     # noinspection PyMethodOverriding
     @classmethod
-    def build(cls, path_locator: "PathLocator", schema: "Schema", name: str, mappings: Dict):
+    def build(cls, schema: "Schema", lookups_dir: str, name: str, mappings: Dict, **kwargs_ignore) -> "Scan":
         scan_subclasses: Dict[str, Type] = load(cls)
         instance_subclass: Type = scan_subclasses[name]
         return instance_subclass(**mappings, schema=schema)

--- a/polytropos/actions/step.py
+++ b/polytropos/actions/step.py
@@ -3,14 +3,13 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from polytropos.ontology.paths import PathLocator
     from polytropos.ontology.schema import Schema
 class Step(Callable):
 
     @classmethod
     @abstractmethod
-    def build(cls, *, path_locator: "PathLocator", schema: "Schema", **kwargs):
-        """Build takes always a path locator and a schema, there are other
+    def build(cls, *, lookups_dir: str, schema: "Schema", **kwargs) -> "Step":
+        """Build takes always a lookups directory and a schema, there are other
         keyword arguments that depend on the implementation"""
         pass
 

--- a/polytropos/actions/translate/__translate.py
+++ b/polytropos/actions/translate/__translate.py
@@ -12,9 +12,6 @@ from polytropos.actions.translate import Translator
 from polytropos.util.config import MAX_WORKERS
 from polytropos.util.exceptions import ExceptionWrapper
 
-if TYPE_CHECKING:
-    from polytropos.ontology.paths import PathLocator
-
 @dataclass
 class Translate(Step):
     target_schema: Schema
@@ -25,15 +22,15 @@ class Translate(Step):
 
     # noinspection PyMethodOverriding
     @classmethod
-    def build(cls, path_locator: "PathLocator", schema: Schema, target_schema: str):
+    def build(cls, *, schema: Schema, schemas_dir: str, target_schema: str, **kwargs_ignore) -> "Translate":
         """
-        :param path_locator:
         :param schema: The source schema, already instantiated.
+        :param schemas_dir: Directory base containing schemas.
         :param target_schema: The path to the definition of the target schema.
         :return:
         """
         logging.info("Initializing Translate step.")
-        target_schema_instance: Schema = Schema.load(target_schema, source_schema=schema, path_locator=path_locator)
+        target_schema_instance: Schema = Schema.load(target_schema, source_schema=schema, base_path=schemas_dir)
         translate_immutable: Translator = Translator(target_schema_instance.immutable)
         translate_temporal: Translator = Translator(target_schema_instance.temporal)
         return cls(target_schema_instance, translate_immutable, translate_temporal)

--- a/test/test_examples/conf.py
+++ b/test/test_examples/conf.py
@@ -1,0 +1,6 @@
+import os
+
+BASEPATH = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_BASE = os.path.join(BASEPATH, '../../test_output')
+
+

--- a/test/test_examples/conftest.py
+++ b/test/test_examples/conftest.py
@@ -7,17 +7,17 @@ import pytest
 from polytropos.ontology.task import Task
 from polytropos.util.compare import compare
 
+from conf import OUTPUT_BASE
 
 @pytest.fixture
 def run_task(basepath) -> Callable:
     def _run_task(scenario, task_name, expected_location):
         conf = os.path.join(basepath, '../examples', scenario, 'conf')
         data = os.path.join(basepath, '../examples', scenario, 'data')
-        task = Task.build(conf, data, task_name)
+        output = os.path.join(OUTPUT_BASE, scenario)
+        task = Task.build(conf, data, output, task_name)
         task.run()
-        actual_path = os.path.join(
-            task.path_locator.entities_dir, task.target_data
-        )
+        actual_path = os.path.join(output, task.target_data)
         expected_path = os.path.join(
             task.path_locator.entities_dir, expected_location
         )

--- a/test/test_examples/test_example_5.py
+++ b/test/test_examples/test_example_5.py
@@ -4,6 +4,8 @@ from polytropos.ontology.task import Task
 import polytropos.actions.consume
 import examples.s_5_tr_export.conf.consumers.count
 
+from conf import OUTPUT_BASE
+
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.fixture(scope='module', autouse=True)
@@ -32,9 +34,10 @@ def cleanup():
 def test_task_consume(scenario, task_name, expected_location):
     conf = os.path.join(BASEPATH, '../../examples', scenario, 'conf')
     data = os.path.join(BASEPATH, '../../examples', scenario, 'data')
-    task = Task.build(conf, data, task_name)
+    output = os.path.join(OUTPUT_BASE, scenario)
+    task = Task.build(conf, data, output, task_name)
     task.run()
-    actual_path = os.path.join(task.path_locator.conf_dir, '../')
+    actual_path = output
     expected_path = os.path.join(
         task.path_locator.conf_dir, '../', expected_location
     )


### PR DESCRIPTION
- Removed PathLocator from build() args of Step and its subclasses,
  which receive instead the individual directories.
- Moved test output of test_examples from examples/ to test_output/